### PR TITLE
deploy: added service instance ID to object names

### DIFF
--- a/playbooks/test.yml
+++ b/playbooks/test.yml
@@ -5,6 +5,7 @@
   vars:
     finish_tests: False
     action: test
+    _apb_service_instance_id: 15c0e133-2a28-4795-a428-638a28c36072
   roles:
   - role: ansible.kubernetes-modules
     install_python_requirements: no

--- a/roles/deprovision-mssql-apb/defaults/main.yml
+++ b/roles/deprovision-mssql-apb/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+service_name: "mssql-server"

--- a/roles/deprovision-mssql-apb/tasks/main.yml
+++ b/roles/deprovision-mssql-apb/tasks/main.yml
@@ -10,7 +10,7 @@
 ## Deprovision a service
 ##############################################################################
 - k8s_v1_service:
-    name: mssql-server
+    name: '{{ service_name }}-{{ _apb_service_instance_id }}'
     namespace: '{{ namespace }}'
     state: absent
 
@@ -21,7 +21,7 @@
 ## its associated resources like replication controllers and pods
 ##############################################################################
 - openshift_v1_deployment_config:
-    name: mssql-server
+    name: '{{ service_name }}-{{ _apb_service_instance_id }}' 
     namespace: '{{ namespace }}'
     state: absent
 
@@ -30,6 +30,6 @@
 ## Deprovision a secret
 ##############################################################################
 - k8s_v1_secret:
-    name: mssql-server
+    name: '{{ service_name }}-{{ _apb_service_instance_id }}'
     namespace: '{{ namespace }}'
     state: absent

--- a/roles/provision-mssql-apb/tasks/main.yml
+++ b/roles/provision-mssql-apb/tasks/main.yml
@@ -5,14 +5,9 @@
 ## below are some sample resources for getting started deploying an application
 ## to OpenShift.
 ##############################################################################
-#- name: create a unique id
-#  shell: "echo $RANDOM | tr '[0-9]' '[a-zA-Z]'"
-#  register: my_unique_id
-
 - name: create secret
   k8s_v1_secret:
-#    name: '{{ service_name }}-{{ my_unique_id.stdout }}'
-    name: '{{ service_name }}'
+    name: '{{ service_name }}-{{ _apb_service_instance_id }}'
     namespace: '{{ namespace }}'
     string_data:
       ACCEPT_EULA: "Y"
@@ -28,23 +23,22 @@
 ##############################################################################
 - name: create deployment config
   openshift_v1_deployment_config:
-    name: '{{ service_name }}'
+    name: '{{ service_name }}-{{ _apb_service_instance_id }}'
     namespace: '{{ namespace }}'
     labels:
-      app: '{{ service_name }}'
-      service: '{{ service_name }}'
+      app: '{{ service_name }}-{{ _apb_service_instance_id }}'
+      service: '{{ service_name }}-{{ _apb_service_instance_id }}'
     replicas: 1
     selector:
-      app: '{{ service_name }}'
-      service: '{{ service_name }}'
+      app: '{{ service_name }}-{{ _apb_service_instance_id }}'
+      service: '{{ service_name }}-{{ _apb_service_instance_id }}'
     spec_template_metadata_labels:
-      app: '{{ service_name }}'
-      service: '{{ service_name }}'
+      app: '{{ service_name }}-{{ _apb_service_instance_id }}'
+      service: '{{ service_name }}-{{ _apb_service_instance_id }}'
     containers:
     - envFrom:
       - secretRef:
-#          name: '{{ service_name }}-{{ my_unique_id.stdout }}'
-          name: '{{ service_name }}'
+          name: '{{ service_name }}-{{ _apb_service_instance_id }}'
       image: '{{ mssql_image }}:{{ mssql_image_tag }}'
       name: '{{ service_name }}'
       livenessProbe:
@@ -83,18 +77,18 @@
 ## set of replicated pods in order to proxy the connections it receives to them.
 ## https://docs.openshift.org/latest/architecture/core_concepts/pods_and_services.html#services
 ##############################################################################
-- name: create '{{ service_name }}' service
+- name: create '{{ service_name }}-{{ _apb_service_instance_id }}' service
   k8s_v1_service:
-    name: '{{ service_name }}'
+    name: '{{ service_name }}-{{ _apb_service_instance_id }}'
     namespace: '{{ namespace }}'
     labels:
-      app: '{{ service_name }}'
-      service: '{{ service_name }}'
+      app: '{{ service_name }}-{{ _apb_service_instance_id }}'
+      service: '{{ service_name }}-{{ _apb_service_instance_id }}'
     selector:
-      app: '{{ service_name }}'
-      service: '{{ service_name }}'
+      app: '{{ service_name }}-{{ _apb_service_instance_id }}'
+      service: '{{ service_name }}-{{ _apb_service_instance_id }}'
     ports:
-      - name: '{{ service_name }}'
+      - name: '{{ service_name }}-{{ _apb_service_instance_id }}'
         port: 1433
         target_port: 1433
     state: '{{ state }}'
@@ -104,7 +98,7 @@
   asb_encode_binding:
     fields:
       DB_TYPE: "mssql"
-      DB_HOST: "{{ service_name }}"
+      DB_HOST: "{{ service_name }}-{{ _apb_service_instance_id }}"
       DB_PORT: "1433"
       DB_ADMIN_USER: "SA"
       DB_ADMIN_PASSWORD: "{{ mssql_sa_pw }}"


### PR DESCRIPTION
Adding `_apb_service_instance_id` to objects name allows to have multiple deployments in the same namespace.

`_apb_service_instance_id` is a UUID string, unique to each deployment. Downside, the names are rather large.