### PR TITLE
move db create to readiness probe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,11 +128,6 @@ ICAgIGRpc3BsYXlfZ3JvdXA6IEVudmlyb25tZW50IFNpemluZwo="
 
 COPY playbooks /opt/apb/actions
 COPY roles /opt/ansible/roles
-RUN yum -y install --setopt=tsflags=nodocs python-pip && \
-    yum clean all && \
-    chown -R 0 /opt/{ansible,apb} && \
-    pip install --upgrade pip && \
-    pip install pymssql && \
-    chown -R apb:0 /opt/{ansible,apb} && \
+RUN chown -R apb:0 /opt/{ansible,apb} && \
     chmod -R g=u /opt/{ansible,apb}
 USER apb

--- a/roles/provision-mssql-apb/tasks/main.yml
+++ b/roles/provision-mssql-apb/tasks/main.yml
@@ -94,7 +94,11 @@
               - /bin/sh
               - -i
               - -c
-              - sqlcmd -S localhost -U SA -P "$MSSQL_SA_PASSWORD" -Q "SELECT Name from sys.Databases"
+              - |
+                sqlcmd -S localhost -U SA -P "$MSSQL_SA_PASSWORD" -Q "IF DB_ID('{{ mssql_db }}') IS NULL		
+                BEGIN		
+                  CREATE DATABASE {{ mssql_db }}		
+                END"
           initialDelaySeconds: 10
           timeoutSeconds: 1
         resources:
@@ -158,7 +162,11 @@
               - /bin/sh
               - -i
               - -c
-              - sqlcmd -S localhost -U SA -P "$MSSQL_SA_PASSWORD" -Q "SELECT Name from sys.Databases"
+              - |
+                sqlcmd -S localhost -U SA -P "$MSSQL_SA_PASSWORD" -Q "IF DB_ID('{{ mssql_db }}') IS NULL		
+                BEGIN		
+                  CREATE DATABASE {{ mssql_db }}		
+                END"
           initialDelaySeconds: 10
           timeoutSeconds: 1
         resources:
@@ -230,21 +238,9 @@
       DB_URI: 'Data Source={{ service_instance }}.{{ namespace }}.svc,{{ service_port }}; Initial Catalog={{ mssql_db }}; User Id=SA; Password={{ mssql_sa_pw }};'
   when: action == 'provision'
 
-
-##############################################################################
-## Create a new database.
-##############################################################################
-- name: Wait for mssql to come up
-  wait_for:
-    host: '{{ service_instance }}.{{ namespace }}.svc'
-    port: '{{ service_port }}'
-    timeout: 420
-
-- name: Create table
-  mssql_db:
-    login_host: '{{ service_instance }}.{{ namespace }}.svc'
-    login_port: '{{ service_port }}'
-    login_user: SA
-    login_password: '{{ mssql_sa_pw }}'
-    name: '{{ mssql_db }}'
-    state: '{{ state }}'
+- name: Wait for mssql to come up		
+  wait_for:		
+    host: '{{ service_instance }}.{{ namespace }}.svc'		
+    port: '{{ service_port }}'		
+    timeout: 360
+  when: action == 'test'


### PR DESCRIPTION
speeds up deployment and ensures ephemeral deploys always have DB created w/ future DC rollouts. also reduces size of APB image